### PR TITLE
Track whether or not cursor is moving out/into tab's view to enable auto pause/resume behavior for different monitors/windows

### DIFF
--- a/options.html
+++ b/options.html
@@ -96,7 +96,8 @@
         	<label><input type="checkbox" id="lockpause"><span class="label-text">Enable auto pause on computer lock</span></label>
         	<label><input type="checkbox" id="lockresume"><span class="label-text">Enable auto resume on computer unlock</span></label>
         	<label><input type="checkbox" id="scrollpause"><span class="label-text">Enable auto pause when out of viewport</span></label>
-        	<label><input type="checkbox" id="disabled"><span class="label-text">Disable auto pause/resume</span></label>
+        	<label><input type="checkbox" id="disabled"><span class="label-text">Disable auto pause/resume</span></label>	
+			<label><input type="checkbox" id="cursorTracking"><span class="label-text">Enable cursor on window tracking</span></label>
 		</div>
 		<hr>
 		<div class="container">

--- a/options.js
+++ b/options.js
@@ -7,6 +7,7 @@ const options = {
   focuspause: false,
   focusresume: false,
   disabled: false,
+  cursorTracking: false,
 };
 
 var hosts = chrome.runtime.getManifest().host_permissions;
@@ -108,3 +109,8 @@ for (i = 0; i < coll.length; i++) {
     }
   });
 }
+
+// Add event listener for the cursor tracking option
+document
+  .getElementById("cursorTracking")
+  .addEventListener("change", save_options);

--- a/yt.js
+++ b/yt.js
@@ -207,6 +207,15 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     }
   }
 
+  // Handle cursor near edge changes
+  if ("cursorNearEdge" in request) {
+    if (request.cursorNearEdge && options.autopause) {
+      stop(sender.tab);
+    } else if (!request.cursorNearEdge && options.autoresume) {
+      resume(sender.tab);
+    }
+  }
+
   sendResponse({});
   return true;
 });

--- a/yt.js
+++ b/yt.js
@@ -14,6 +14,7 @@ let options = {
   focuspause: false,
   focusresume: false,
   disabled: false,
+  cursorTracking: false,
 };
 
 var hosts = chrome.runtime.getManifest().host_permissions;
@@ -35,6 +36,7 @@ function refresh_settings() {
       options.lockresume = false;
       options.focuspause = false;
       options.focusresume = false;
+      options.cursorTracking = false;
       for (var host of hosts) {
         options[host] = false;
       }
@@ -187,7 +189,11 @@ chrome.windows.onFocusChanged.addListener(async function (window) {
 });
 
 // Message listener for messages from tabs
-chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+chrome.runtime.onMessage.addListener(async function (
+  request,
+  sender,
+  sendResponse
+) {
   if (sender.tab === undefined || chrome.runtime.lastError) {
     return true;
   }
@@ -207,14 +213,18 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     }
   }
 
-  // Handle cursor near edge changes
-  if ("cursorNearEdge" in request) {
-    if (request.cursorNearEdge && options.autopause) {
-      stop(sender.tab);
-    } else if (!request.cursorNearEdge && options.autoresume) {
-      resume(sender.tab);
+  await chrome.storage.sync.get("cursorTracking", function (result) {
+    if (result.cursorTracking) {
+      // Handle cursor near edge changes
+      if ("cursorNearEdge" in request) {
+        if (request.cursorNearEdge && options.autopause) {
+          stop(sender.tab);
+        } else if (!request.cursorNearEdge && options.autoresume) {
+          resume(sender.tab);
+        }
+      }
     }
-  }
+  });
 
   sendResponse({});
   return true;

--- a/yt_auto_pause.js
+++ b/yt_auto_pause.js
@@ -17,21 +17,25 @@ if (window.ytAutoPauseInjected !== true) {
   let cursorNearEdgeTimeout;
 
   // Listen for mousemove events
-  window.addEventListener("mousemove", function (event) {
-    if (isCursorNearEdge(event)) {
-      // If the cursor is near the edge, set a timeout
-      if (!cursorNearEdgeTimeout) {
-        cursorNearEdgeTimeout = setTimeout(function () {
-          sendMessage({ cursorNearEdge: true });
+  window.addEventListener("mousemove", async function (event) {
+    await chrome.storage.sync.get(["cursorTracking"], function (result) {
+      if (result.cursorTracking) {
+        if (isCursorNearEdge(event)) {
+          // If the cursor is near the edge, set a timeout
+          if (!cursorNearEdgeTimeout) {
+            cursorNearEdgeTimeout = setTimeout(function () {
+              sendMessage({ cursorNearEdge: true });
+              cursorNearEdgeTimeout = null;
+            }, 200); // Wait for 1 second to infer user intention
+          }
+        } else {
+          // If the cursor moves away from the edge, clear the timeout
+          clearTimeout(cursorNearEdgeTimeout);
           cursorNearEdgeTimeout = null;
-        }, 200); // Wait for 1 second to infer user intention
+          sendMessage({ cursorNearEdge: false });
+        }
       }
-    } else {
-      // If the cursor moves away from the edge, clear the timeout
-      clearTimeout(cursorNearEdgeTimeout);
-      cursorNearEdgeTimeout = null;
-      sendMessage({ cursorNearEdge: false });
-    }
+    });
   });
 
   // Existing code...

--- a/yt_auto_pause.js
+++ b/yt_auto_pause.js
@@ -3,6 +3,39 @@ if (window.ytAutoPauseInjected !== true) {
   let manuallyPaused = false;
   let automaticallyPaused = false;
 
+  // Function to check if the cursor is near the edge of the window
+  function isCursorNearEdge(event) {
+    const threshold = 50; // pixels from the edge
+    return (
+      event.clientX < threshold ||
+      event.clientX > window.innerWidth - threshold ||
+      event.clientY < threshold ||
+      event.clientY > window.innerHeight - threshold
+    );
+  }
+
+  let cursorNearEdgeTimeout;
+
+  // Listen for mousemove events
+  window.addEventListener("mousemove", function (event) {
+    if (isCursorNearEdge(event)) {
+      // If the cursor is near the edge, set a timeout
+      if (!cursorNearEdgeTimeout) {
+        cursorNearEdgeTimeout = setTimeout(function () {
+          sendMessage({ cursorNearEdge: true });
+          cursorNearEdgeTimeout = null;
+        }, 200); // Wait for 1 second to infer user intention
+      }
+    } else {
+      // If the cursor moves away from the edge, clear the timeout
+      clearTimeout(cursorNearEdgeTimeout);
+      cursorNearEdgeTimeout = null;
+      sendMessage({ cursorNearEdge: false });
+    }
+  });
+
+  // Existing code...
+
   // Send message to service worker
   function sendMessage(message) {
     if (!chrome.runtime?.id) {


### PR DESCRIPTION
added code to track whether cursor is at the edge of the viewport for more than 200ms, indicating intention to move to a different monitor, to pause the video, and then resume it again once the cursor moves back. Added by default, not yet added option button for this.